### PR TITLE
added cleanup,prereq,refresh env 1.1

### DIFF
--- a/website/docs/containers/python/build-image.md
+++ b/website/docs/containers/python/build-image.md
@@ -7,11 +7,19 @@ sidebar_position: 3
 This guide walks you through the process of building container images for our [python-fastapi-demo-docker](https://github.com/aws-samples/python-fastapi-demo-docker) project and running them as distinct services using Docker Compose. By the end, you'll know how to manage your multi-service applications more effectively, ensuring smoother development, deployment, and updates.
 ## Prerequisites
 - [Setting up the Development Environment](../../intro/python/environment-setup.md)
+
 ## 1. Building Docker Images for Each Service
-Navigate to the root directory of the 'python-fastapi-demo-docker' project with the Dockerfile and docker-compose.yml. To build Docker images for the application and database services, run:
+Navigate to the root directory of the 'python-fastapi-demo-docker' project with the Dockerfile and docker-compose.yml.
+
+```bash
+cd python-fastapi-demo-docker
+```
+
+Build Docker images for the application and database services by running:
 ```bash
 docker-compose build
 ```
+
 This builds Docker images based on the configurations in the docker-compose.yml file. Docker follows the Dockerfile instructions during each service's build process, creating separate images for the 'python-fastapi-demo-docker-web' and 'python-fastapi-demo-docker-db' services.
 
 ## 2. Running the Services as Docker Containers

--- a/website/docs/containers/python/integration-ecr.md
+++ b/website/docs/containers/python/integration-ecr.md
@@ -9,7 +9,7 @@ This guide shows to streamline the process of uploading Docker images to Amazon 
 ## Prerequisites
 - [Uploading Container Images to Amazon ECR](upload-ecr.md)
 - [Creating the .env File](../../intro/python/environment-setup#4-creating-the-env-file)
-
+- [Importing environment variables](../../intro/python/environment-setup#5-import-environment-variables)
 
 ## 1. Adjustments to the Dockerfile
 After the successful upload of Docker images to Amazon ECR, no changes are required in the Dockerfile, which serves as a consistent blueprint for defining the environment, dependencies, and image creation steps.

--- a/website/docs/containers/python/multiarchitecture-image.md
+++ b/website/docs/containers/python/multiarchitecture-image.md
@@ -7,6 +7,8 @@ This guide shows you how to create a multi-architecture container image for the 
 
 ## Prerequisites
 - [Integrating Amazon ECR with Docker Compose](integration-ecr.md)
+- [Creating the .env File](../../intro/python/environment-setup#4-creating-the-env-file)
+- [Importing environment variables](../../intro/python/environment-setup#5-import-environment-variables)
 
 ## 1. Logging into Amazon ECR
 From the 'python-fastapi-demo-docker' project directory, authenticate the Docker CLI to your Amazon ECR registry using:

--- a/website/docs/containers/python/upload-ecr.md
+++ b/website/docs/containers/python/upload-ecr.md
@@ -5,15 +5,13 @@ sidebar_position: 4
 ## Overview
 Learn how to leverage Amazon Elastic Container Registry (ECR) as a secure and efficient storage solution for Docker images in the context of our [python-fastapi-demo-docker](https://github.com/aws-samples/python-fastapi-demo-docker) project.
 
-## Prerequisites
-- [Building and Running the Docker Containers](./build-image.md)
-- [Creating the .env File](../../intro/python/environment-setup#4-creating-the-env-file)
-
 ## Objective
 This tutorial simplifies the process of pushing Docker images to Amazon ECR using the FastAPI and PostgreSQL images from our [python-fastapi-demo-docker](https://github.com/aws-samples/python-fastapi-demo-docker) project. We'll showcase how uploading these Docker images to ECR enhances your development, testing, and deployment workflows by making the images accessible across different environments.
 
 ## Prerequisites
 - [Building and Running the Docker Containers](build-image.md)
+- [Creating the .env File](../../intro/python/environment-setup#4-creating-the-env-file)
+- [Importing environment variables](../../intro/python/environment-setup#5-import-environment-variables)
 
 ## 1. Creating an ECR Repository
 Create a new private Amazon ECR repository:


### PR DESCRIPTION
- [ ] Docs: Guiding Developers Through Environment Variables Sourcing Throughout Workshop
  - Added Prerequisites to the concerned pages with intention to remind the users that they need to add and import environment variables.
  - Added the suggested verbage.
- [ ] Docs: Improve Flow of Integrating Amazon ECR with Docker Compose
   - There was confusion in `4. Updating Docker Images` section of `Integrating Amazon ECR with Docker Compose` page. This mostly was related to Two issues.
      1. After adding Environment variable `IMAGE_VERSION=1.1` a refresh is required. I added necessary steps for the refresh.
      2. `docker-compose build web` directly created image with ECR repo tag. There was an unnessary step of tagging fastapi-microservices:1.1. I removed this step.
       ```          
       docker tag fastapi-microservices:${IMAGE_VERSION} ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION}
       ```
 
- [ ] Docs: Add Lab Cleanup Option Throughout the Workshop (updated containers  section only for now)
   -  Added cleanup step for `Integrating Amazon ECR with Docker Compose` and `Building and Running Multi-Architecture Containers` to clean up local images. 
