### PR TITLE
Update NPM version and Node version to match Docusaurus 2.x requirements

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -2,8 +2,8 @@
 This guide provides instructions for setting up and running [Docusaurus](https://docusaurus.io/) for contributors to the EKS Developers Workshop documentation. It includes steps to create a fork, manage branches, and best practices for contributing.
 
 ### Prerequisites
-- [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (version 14.x or higher)
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (version 6.x or higher)
+- [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (version 16.x or higher)
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (version 8.x or higher)
 
 ### Setup
 Before you can start contributing to the documentation, you need to set up Docusaurus locally. 


### PR DESCRIPTION
Docusaurus 2.x lists nodejs 16+ requirement.

# What problem does it solve?

Attempting to build using node 14 results in errors due to the use of the nullish coalescing assignment operator.

```
➜ npm run build 

> website@0.0.0 build /workplace/jbnorth/eks-workshop-developers/website
> docusaurus build

file:///workplace/jbnorth/eks-workshop-developers/website/node_modules/@docusaurus/core/bin/docusaurus.mjs:30
process.env.BABEL_ENV ??= 'development';
                      ^^^

SyntaxError: Unexpected token '??='
    at Loader.moduleStrategy (internal/modules/esm/translators.js:145:18)
    at async link (internal/modules/esm/module_job.js:67:21)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! website@0.0.0 build: `docusaurus build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the website@0.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

Summarize the changes and the motivation behind your changes. 

- Updated `authoring.md` to correctly list the requirements for nodejs 16+ and npm 8.x

## Type of change

- [X] Bug fix or improvement (non-breaking change which fixes an issue)
- [ ] New lab exercise (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing workshop materials to not work as expected)

# How Can Other Contributors Test Your Changes?

Describe the tests that you ran to verify your changes so that other contributors can reproduce your steps. 

- [X] N/A
- [ ] Describe below:


# Checklist:

- [X] My contributions follow the style guidelines of this project
- [X] I have performed a self-review of my changes
- [ ] I have added tests that prove my changes are effective

