### PR TITLE
Fixed finch compose command syntax

### DIFF
--- a/website/docs/python/containers/build-image.md
+++ b/website/docs/python/containers/build-image.md
@@ -26,7 +26,7 @@ docker-compose build
 Alternatively, if you're using Finch, run the following command to build the container images for the application and database:
 
 ```bash
-finch compose build --platform linux/amd64
+finch compose build
 ```
 
 This builds Docker images based on the configurations in the docker-compose.yml file. Docker follows the Dockerfile instructions during each service's build process, creating separate images for the 'python-fastapi-demo-docker-web' and 'python-fastapi-demo-docker-db' services.


### PR DESCRIPTION
# What problem does it solve?

Fixed incorrect syntax for finch compose by removing the --platform, which is not valid for finch compose sub command options.

Summarize the changes and the motivation behind your changes. 
removed  --platform option
- 

## Type of change

- [ X] Bug fix or improvement (non-breaking change which fixes an issue)
- [ ] New lab exercise (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing workshop materials to not work as expected)

# How Can Other Contributors Test Your Changes?
clone the python-fastapi-demo-docker repository
cd python-fastapi-demo-docker
finch compose up
open browser and verify website

Describe the tests that you ran to verify your changes so that other contributors can reproduce your steps. 

- [ ] N/A
- [ X] Describe below:

Ran compose up and verified the build and website was working as expected locally.

# Checklist:

- [ ] My contributions follow the [style guidelines](../docs/style-guide.md) of this project
- [X ] I have performed a self-review of my changes
- [ ] I have added tests that prove my changes are effective

