### PR TITLE
Remove references to AWS credentials in .env file

### DIFF
--- a/website/docs/python/introduction/environment-setup.md
+++ b/website/docs/python/introduction/environment-setup.md
@@ -64,12 +64,10 @@ cd python-fastapi-demo-docker
 cp .env.example .env
 ```
 
-Now add your AWS credentials to the `.env` file you just created:
+Now update AWS variables in the `.env` file you just created using the AWS Account ID and region that you will use for this workshop:
 
 ```bash
 AWS_ACCOUNT_ID=012345678901
-AWS_ACCESS_KEY_ID=ASIAWNZPPVHEXAMPLE
-AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLE
 AWS_REGION=us-east-1
 ```
 

--- a/website/docs/python/kubernetes/deploy-secrets.md
+++ b/website/docs/python/kubernetes/deploy-secrets.md
@@ -76,8 +76,6 @@ Type:  Opaque
 
 Data
 ====
-AWS_SECRET_ACCESS_KEY:       40 bytes
-AWS_SESSION_TOKEN:           764 bytes
 DATABASE_URL:                58 bytes
 HTTP_HOST:                   16 bytes
 IMAGE_VERSION:               3 bytes
@@ -87,7 +85,6 @@ DOCKER_DATABASE_URL:         53 bytes
 POSTGRES_MASTER:             8 bytes
 POSTGRES_TABLE:              5 bytes
 APP_HOST:                    7 bytes
-AWS_ACCESS_KEY_ID:           20 bytes
 POSTGRES_HOST:               9 bytes
 POSTGRES_PASSWORD:           15 bytes
 POSTGRES_VOLUME:             2 bytes


### PR DESCRIPTION
# What problem does it solve?

AWS access key and secret key are removed from .env file. https://github.com/aws-samples/python-fastapi-demo-docker/pull/32

This PR removes references to these variables in the workshop.
The workshop already guides the user to use `aws configure` to set up AWS credentials - https://github.com/aws-samples/eks-workshop-developers/blob/main/website/docs/python/introduction/environment-setup.md#3-configuring-the-shell-environment

There is no need to have AWS access key and secret key in the .env file.
Also, removing credentials from the .env file will separate user permissions setup from app env variables. Then the user can make use of IAM roles instead of hardcoding access key and secret key in .env file.

- 

## Type of change

- [x] Bug fix or improvement (non-breaking change which fixes an issue)
- [ ] New lab exercise (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing workshop materials to not work as expected)

# How Can Other Contributors Test Your Changes?

Describe the tests that you ran to verify your changes so that other contributors can reproduce your steps. 

- [ ] N/A
- [x] Describe below:

Contributors can run workshop section "Environment Setup" and then run workshop labs to ensure this change doesn't affect existing labs.

I have ran the labs myself after making this change and didn't find any issues. In fact, this change facilitated the use of instance role and aws cli profiles.

# Checklist:

- [x] My contributions follow the [style guidelines](../docs/style-guide.md) of this project
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my changes are effective

