### PR TITLE
fix: Finch multi-arch build commands incorrect

### DIFF
--- a/website/docs/python/containers/multiarchitecture-image.md
+++ b/website/docs/python/containers/multiarchitecture-image.md
@@ -39,7 +39,7 @@ aws ecr get-login-password \
 
 ## 2. Building Multi-Architecture Docker Image for the Web Service
 
-You can use 'docker buildx' to build Docker images for application and database services that are compatible with multiple architectures, including Kubernetes clusters.
+You can use `docker buildx` to build Docker images for application and database services that are compatible with multiple architectures, including Kubernetes clusters.
 
 First, create and start new builder instances for the web service:
 
@@ -67,8 +67,14 @@ Status:    running
 Platforms: linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
 ```
 
-> Note: There is no direct equivalent for `buildx` using Finch. You can target a set of platforms though.
->The `finch build` command allows targeting different platforms via the `--platform` flag, similar to buildx. You can build binaries for Linux, macOS, and Windows on AMD64 or ARM architectures. For example: `finch build --platform=amd64,arm64 .` to target both AMD and ARM architectures.
+Alternatively, if you're using Finch, run the following command to build the multi-architecture image:
+
+```bash
+finch build \
+    --platform linux/amd64,linux/arm64 \
+    --tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION} \
+    .
+```
 
 ## 3. Pushing the Image to Amazon ECR
 
@@ -79,10 +85,12 @@ docker buildx use webBuilder
 docker buildx build --platform linux/amd64,linux/arm64 -t ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION} . --push
 ```
 
-Alternatively, if you're using Finch, you can target the platform architecture using the following command:
+Alternatively, if you're using Finch, upload the images to ECR using the following command:
 
 ```bash
-finch build --platform=linux/amd64,linux/arm64 -t ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION} . push=true
+finch push \
+    --all-platforms \
+    ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION}
 ```
 
 This builds Docker images based on the Dockerfile instructions and pushes them to your ECR repository.
@@ -192,7 +200,14 @@ docker buildx build --platform linux/amd64,linux/arm64 -t ${AWS_ACCOUNT_ID}.dkr.
 Alternatively, if you're using Finch, you can run:
 
 ```bash
-finch build --platform=linux/amd64,linux/arm64 -t ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION} . push=true
+finch build \
+    --platform linux/amd64,linux/arm64 \
+    --tag ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION} \
+    .
+
+finch push \
+    --all-platforms \
+    ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/fastapi-microservices:${IMAGE_VERSION}
 ```
 
 This command rebuilds the Docker image and pushes it to your ECR repository.
@@ -214,7 +229,7 @@ finch rmi $(finch images -f "dangling=true" -q)
 
 ## Conclusion
 
-This lab explored the process of constructing and executing Docker containers using Docker Compose in the 'python-fastapi-demo-docker' project. We also demonstrated how to use Docker's buildx feature to create Docker images that are compatible with multiple CPU architectures. This approach provides an efficient way to manage multi-service applications, enhancing their portability and ensuring they can run on a wider range of platforms.
+This lab explored the process of constructing and executing Docker containers using Docker Compose in the `python-fastapi-demo-docker` project. We also demonstrated how to use Docker's buildx feature to create Docker images that are compatible with multiple CPU architectures. This approach provides an efficient way to manage multi-service applications, enhancing their portability and ensuring they can run on a wider range of platforms.
 
 ## What's Next?
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8581,7 +8581,7 @@ webpack-bundle-analyzer@^4.9.0:
 
 webpack-dev-middleware@^5.3.1:
   version "5.3.4"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
+  resolved "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz"
   integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
   dependencies:
     colorette "^2.0.10"


### PR DESCRIPTION
# What problem does it solve?

Existing command to build and push multi-arch images in one step using Finch do not actually push the images to the image repository. The `push=true` flag previously accomplished this but is no longer true for the latest Finch versions.

Instead, separate commands are required to first build the images and then push all of the images at once so a multi-arch index is created.

- 

## Type of change

- [x] Bug fix or improvement (non-breaking change which fixes an issue)
- [ ] New lab exercise (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing workshop materials to not work as expected)

# How Can Other Contributors Test Your Changes?

Describe the tests that you ran to verify your changes so that other contributors can reproduce your steps. 

- [ ] N/A
- [x] Describe below:

1. Attempt to use the existing commands found in `website/docs/python/containers/multiarchitecture-image.md` to build and push the multi-arch images using Finch. It should be seen that the images are build but never uploaded to the image repository.
2. Try the same using the new commands. It should be seen that the images are built and then pushed to the image repository.

# Checklist:

- [x] My contributions follow the [style guidelines](../docs/style-guide.md) of this project
- [x] I have performed a self-review of my changes
- [x] I have added tests that prove my changes are effective

