### PR TITLE
fix(deps): Bump brace-expansion to fix high severity DoS vulnerabilities

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -58,7 +58,7 @@
     "follow-redirects": "^1.16.0",
     "picomatch": "^2.3.2",
     "serialize-javascript": "^7.0.5",
-    "brace-expansion": "^2.0.1",
+    "brace-expansion": "^2.1.2",
     "webpack": "~5.105.4"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3511,7 +3511,7 @@ autoprefixer@^10.4.19, autoprefixer@^10.4.23:
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
 
-axios@^1.15.0:
+axios@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.19.0.tgz#ddf864d4c8233c0e6873746ab59361537d05ad39"
   integrity sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==
@@ -3657,10 +3657,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7, brace-expansion@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
-  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+brace-expansion@^1.1.7, brace-expansion@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Summary

Bumps `brace-expansion` resolution from `^2.0.1` to `^2.1.2` (resolves to 2.1.4) to fix two high severity vulnerabilities:

### Resolved Alerts

- **#324** - DoS via exponential-time expansion of consecutive non-expanding {} groups (patched in 2.1.2)
- **#332** - DoS via unbounded expansion length causing out-of-memory process crash (patched in 2.1.2+ for v2.x line)

### Changes

- Updated `resolutions` in `website/package.json`
- Regenerated `website/yarn.lock`