### PR TITLE
fix(website): Bump uuid to patched v14.0.0 via resolution

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -61,7 +61,8 @@
     "brace-expansion": "^2.1.2",
     "webpack": "~5.105.4",
     "ws": "^8.21.0",
-    "js-yaml": "^4.3.0"
+    "js-yaml": "^4.3.0",
+    "uuid": "^14.0.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -9170,10 +9170,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^14.0.0, uuid@^8.3.2:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary
Fixes Dependabot alert [#229](https://github.com/aws-samples/eks-workshop-developers/security/dependabot/229) (moderate): `uuid` missing buffer bounds check in `v3`/`v5`/`v6` when a `buf` is provided (GHSA-w5hq-g745-h8pq).

`uuid@8.3.2` is a transitive dependency pulled in by `sockjs` (used by `webpack-dev-server`), pinned via `uuid@^8.3.2`. Fixed upstream in `uuid@14.0.0`.

## Change
Add a `resolutions` override in `website/package.json` to force `uuid@^14.0.0` across the tree — same pattern already used there for `axios`, `follow-redirects`, `js-yaml`, etc.

## Compatibility note
`uuid@12+` dropped CommonJS support, and `sockjs` calls `require('uuid').v4` (plain CJS). This was verified rather than assumed safe:
- `require('uuid').v4()` succeeds under Node's `require(esm)` interop
- `yarn build` compiles successfully
- `yarn start` boots and serves the dev server (`HTTP 200`) with no `ERR_REQUIRE_ESM` or sockjs errors

## Testing
- [x] `yarn install`
- [x] `yarn build`
- [x] `yarn start` smoke test
